### PR TITLE
Autocomplete trait

### DIFF
--- a/traits/DefaultImageBehaviorIDEAutocompleteTrait.php
+++ b/traits/DefaultImageBehaviorIDEAutocompleteTrait.php
@@ -1,0 +1,28 @@
+<?php
+namespace circulon\images\behaviors;
+
+/**
+ * @method \circulon\images\models\Image attachImage($newImage, $isMain = false)
+ * @see \circulon\images\behaviors\ImageBehavior::attachImage
+ *
+ * @method void setMainImage(\circulon\images\models\Image $img)
+ * @see \circulon\images\behaviors\ImageBehavior::setMainImage
+ *
+ * @methid bool clearImagesCache()
+ * @see \circulon\images\behaviors\ImageBehavior::clearImagesCache
+ *
+ * @method \circulon\images\models\Image[] getImages($usePlaceholder = true)
+ * @see \circulon\images\behaviors\ImageBehavior::getImages
+ *
+ * @method null|\circulon\images\models\Image|\circulon\images\models\Placeholder getImage($id = null, $usePlaceholder = true)
+ * @see \circulon\images\behaviors\ImageBehavior::getImage
+ *
+ * @method void removeImages()
+ * @see \circulon\images\behaviors\ImageBehavior::removeImages
+ *
+ * @method void removeImage(\circulon\images\models\Image $img)
+ * @see \circulon\images\behaviors\ImageBehavior::removeImage
+ */
+trait DefaultImageBehaviorIDEAutocompleteTrait {
+
+}

--- a/traits/DefaultImageBehaviorIDEAutocompleteTrait.php
+++ b/traits/DefaultImageBehaviorIDEAutocompleteTrait.php
@@ -1,5 +1,5 @@
 <?php
-namespace circulon\images\behaviors;
+namespace circulon\images\traits;
 
 /**
  * @method \circulon\images\models\Image attachImage($newImage, $isMain = false)


### PR DESCRIPTION
In case if you want to be able to use autocomplete on model, where behavior was attached, you can just add this section to your model:

``` php
class Product extends \yii\db\ActiveRecord{
// ...
    use \circulon\images\traits\DefaultImageBehaviorIDEAutocompleteTrait;
// ...
}
```

And now you have autocomplete for all these methods "from the box" without writing any line of code.

P.S. Sorry for my Engrish.
